### PR TITLE
vimdiff(neovim -d or vim -d)を使えばいいことがわかった

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -27,10 +27,6 @@ if test uname = 'Linux'
   alias open 'gnome-www-browser'
 end
 
-if [ -x (which opendiff) ]
-  alias diff='opendiff'
-end
-
 # FZF
 alias gco 'git branch | fzf | xargs git checkout'
 alias gbr 'git branch | fzf -m | xargs git branch -d'


### PR DESCRIPTION
https://tyablog.net/2018/03/04/lets-vimdiff/



> コマンド | 説明
> -- | --
> do (diff obtain) | 自身側(カーソルのあるウィンドウ)に他方の差分行を持ってくる。
> dp (diff put) | 自身側(カーソルのあるウィンドウ)から、他方へ差分行を置きにいく。
> 
> <p style="margin: 0px 0px 1.5em; color: rgb(51, 51, 51); font-family: Arial, &quot;Hiragino Kaku Gothic ProN&quot;, Meiryo, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">obtain と、put のイメージをもっておけば迷わずに使うことができます。</p><ul style="margin: 0px 0px 1.5em 2em; padding: 0px; color: rgb(51, 51, 51); font-family: Arial, &quot;Hiragino Kaku Gothic ProN&quot;, Meiryo, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>obtain ... 持ってくる</li><li>put ... 置きにいく</li></ul>