### PR TITLE
Add a keymap to print current date

### DIFF
--- a/nvim/keymap.rc.vim
+++ b/nvim/keymap.rc.vim
@@ -56,6 +56,9 @@ nnoremap <Leader>s( ciw()<Esc>P
 nnoremap <Leader>s{ ciw{}<Esc>P
 nnoremap <Leader>s[ ciw[]<Esc>P
 
+" Print current date
+inoremap <F5> <C-R>=strftime("%Y-%m-%d")<CR>
+
 " Help
 nnoremap <silent> <Space>h :help <C-r><C-w><CR>
 


### PR DESCRIPTION
挿入モードで現在日付（例: 2021-12-22）を出力するキーマップを追加

用途
- Hugo投稿日時
- 日報など