### PR TITLE
feat: Dracula ProパレットをベースにDraculaテーマへ切り替え

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -5,3 +5,26 @@ window-padding-x = 0
 window-padding-y = 0
 
 macos-option-as-alt = left
+
+palette = 0=#22212C
+palette = 1=#FF9580
+palette = 2=#8AFF80
+palette = 3=#FFFF80
+palette = 4=#9580FF
+palette = 5=#FF80BF
+palette = 6=#80FFEA
+palette = 7=#F8F8F2
+palette = 8=#504C67
+palette = 9=#FFAA99
+palette = 10=#A2FF99
+palette = 11=#FFFF99
+palette = 12=#AA99FF
+palette = 13=#FF99CC
+palette = 14=#99FFEE
+palette = 15=#FFFFFF
+background = #22212C
+foreground = #F8F8F2
+cursor-color = #7970A9
+cursor-text = #7970A9
+selection-background = #454158
+selection-foreground = #F8F8F2

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -8,6 +8,7 @@
   "copilot.lua": { "branch": "master", "commit": "faa347cef2a9429eec14dada549e000a3b8d0fc9" },
   "denops.vim": { "branch": "main", "commit": "1df7a022d6e9cb3f6a3db43235e0f174ccd79e03" },
   "dial.nvim": { "branch": "master", "commit": "f2634758455cfa52a8acea6f142dcd6271a1bf57" },
+  "dracula.nvim": { "branch": "main", "commit": "ae752c13e95fb7c5f58da4b5123cb804ea7568ee" },
   "flash.nvim": { "branch": "main", "commit": "fcea7ff883235d9024dc41e638f164a450c14ca2" },
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
   "gitsigns.nvim": { "branch": "main", "commit": "e1b90b60fb7aa9c0ada8e983b460764b35a05e2e" },

--- a/nvim/lua/kseki2/core/options.lua
+++ b/nvim/lua/kseki2/core/options.lua
@@ -10,7 +10,7 @@ opt.relativenumber = true
 opt.number = true
 opt.numberwidth = 5
 
-opt.wrap = false
+opt.wrap = true
 
 -- Tab & Indentation
 opt.shiftwidth = 2

--- a/nvim/lua/kseki2/plugins/colorschema.lua
+++ b/nvim/lua/kseki2/plugins/colorschema.lua
@@ -8,8 +8,45 @@ return {
   },
   {
     "EdenEast/nightfox.nvim",
+    enabled = false,
     config = function()
       vim.cmd("colorscheme nordfox")
+    end,
+  },
+  {
+    "Mofiqul/dracula.nvim",
+    priority = 1000,
+    config = function()
+      require("dracula").setup({
+        overrides = {
+          -- tabby.nvim が使う TabLine 系グループを Dracula Pro 配色で上書き
+          TabLineFill = { bg = "#17161D" },
+          TabLine     = { fg = "#7970A9", bg = "#2E2B3B" },
+          TabLineSel  = { fg = "#F8F8F2", bg = "#22212C", bold = true },
+        },
+        colors = {
+          -- Dracula Pro palette overrides
+          bg          = "#22212C",
+          fg          = "#F8F8F2",
+          selection   = "#454158",
+          comment     = "#7970A9",
+          red         = "#FF9580",
+          orange      = "#FFCA80",
+          yellow      = "#FFFF80",
+          green       = "#8AFF80",
+          purple      = "#9580FF",
+          cyan        = "#80FFEA",
+          pink        = "#FF80BF",
+          bright_red  = "#FFAA99",
+          bright_green = "#A2FF99",
+          bright_yellow = "#FFFF99",
+          bright_cyan = "#99FFEE",
+          menu        = "#2E2B3B",
+          visual      = "#454158",
+          black       = "#17161D",
+        },
+      })
+      vim.cmd("colorscheme dracula")
     end,
   },
 }


### PR DESCRIPTION
## Summary

- `Mofiqul/dracula.nvim` を追加し、Dracula Pro の配色（bg/fg/selection/comment など）で上書き設定
- ghostty のターミナルカラーパレットを Dracula Pro に統一
- tabby.nvim の TabLine 系ハイライトグループ（TabLineFill / TabLine / TabLineSel）を Dracula Pro 配色で調整
- `EdenEast/nightfox.nvim` を `enabled = false` に変更
- `opt.wrap = true` に変更

## Test plan

- [x] Neovim 起動後 `:Lazy sync` でプラグインインストール確認
- [x] Dracula テーマが正しく適用されていること
- [x] tabby.nvim のタブバーの配色が意図通りであること
- [x] ghostty のターミナル色が Dracula Pro 配色になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)