### PR TITLE
feat: catppuccin/nvimをカラースキームとして追加

### DIFF
--- a/nvim/lua/kseki2/plugins/colorschema.lua
+++ b/nvim/lua/kseki2/plugins/colorschema.lua
@@ -8,8 +8,28 @@ return {
   },
   {
     "EdenEast/nightfox.nvim",
+    enabled = false,
     config = function()
       vim.cmd("colorscheme nordfox")
+    end,
+  },
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    priority = 1000,
+    config = function()
+      require("catppuccin").setup({
+        flavour = "mocha",
+        integrations = {
+          blink_cmp = true,
+          gitsigns = true,
+          treesitter = true,
+          which_key = true,
+          lsp_trouble = true,
+          snacks = true,
+        },
+      })
+      vim.cmd("colorscheme catppuccin")
     end,
   },
 }


### PR DESCRIPTION
## Summary

- catppuccin/nvim を新しいカラースキームとして追加（flavour: mocha）
- nightfox.nvim を `enabled = false` に変更
- blink-cmp, gitsigns, treesitter, which-key, trouble, snacks との integrations を設定

## Test plan

- [x] Neovim を起動して catppuccin mocha テーマが適用されることを確認
- [x] `:Lazy` でプラグインが正常にインストールされることを確認
- [x] 各統合プラグイン（gitsigns, which-key 等）のハイライトが適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)