### PR TITLE
feat: blink.cmpで補完候補未選択時のEnterを通常の改行にする

### DIFF
--- a/nvim/lua/kseki2/plugins/blink-cmp.lua
+++ b/nvim/lua/kseki2/plugins/blink-cmp.lua
@@ -50,6 +50,7 @@ return {
     },
     completion = {
       accept = { auto_brackets = { enabled = true } },
+      list = { selection = { preselect = false } },
       menu = { border = "rounded" },
       documentation = {
         auto_show = true,


### PR DESCRIPTION
## Summary
- blink.cmp で補完メニュー表示中に先頭候補が自動選択されてしまい、未選択のつもりでEnterを押しても先頭候補が確定される挙動を解消
- `completion.list.selection.preselect = false` を追加し、`<C-n>`/`<C-p>` で明示的に選んだ候補のみEnterで確定するよう変更

## Test plan
- [x] nvim 再起動後、補完メニューが出た直後にEnter → 通常の改行になる
- [x] `<C-n>`/`<C-p>` で候補を選択してからEnter → 選択した候補が確定される

🤖 Generated with [Claude Code](https://claude.com/claude-code)