### PR TITLE
feat: Neovimで行折り返し(wrap)を有効化

### DIFF
--- a/nvim/lua/kseki2/core/options.lua
+++ b/nvim/lua/kseki2/core/options.lua
@@ -10,7 +10,7 @@ opt.relativenumber = true
 opt.number = true
 opt.numberwidth = 5
 
-opt.wrap = false
+opt.wrap = true
 
 -- Tab & Indentation
 opt.shiftwidth = 2


### PR DESCRIPTION
## Summary
- `nvim/lua/kseki2/core/options.lua` の `opt.wrap` を `false` から `true` に変更し、長い行を折り返して表示するようにした

## Test plan
- [x] Neovimを起動し、長い行を含むファイルを開いて折り返し表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)